### PR TITLE
(#11) Update ffi and rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     color (1.8)
     deprecated (2.0.1)
     diff-lcs (1.3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     flexmock (2.3.5)
     highline (1.7.8)
     hpricot (0.8.6)
@@ -70,7 +70,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sbsm (1.5.6)
       chrono_logger
       hpricot
@@ -156,4 +156,4 @@ DEPENDENCIES
   yus
 
 BUNDLED WITH
-   1.16.0
+   1.16.6


### PR DESCRIPTION
Hope this helps. Yard still has a reference to a too old ffi
<pre>
    childprocess (0.7.0)
      ffi (~> 1.0, >= 1.0.11)
</pre>